### PR TITLE
make trace methods thread safe

### DIFF
--- a/finagle-thrift/src/main/ruby/.gitignore
+++ b/finagle-thrift/src/main/ruby/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/finagle-thrift/src/main/ruby/Gemfile
+++ b/finagle-thrift/src/main/ruby/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in finagle-thrift.gemspec
+gemspec
+

--- a/finagle-thrift/src/main/ruby/finagle-thrift.gemspec
+++ b/finagle-thrift/src/main/ruby/finagle-thrift.gemspec
@@ -20,4 +20,7 @@ Gem::Specification.new do |s|
 
   s.files        = Dir.glob("{bin,lib}/**/*")
   s.require_path = 'lib'
+
+  s.add_dependency 'test-unit'
+  s.add_dependency 'thread_safe', '~> 0.3.4'
 end

--- a/finagle-thrift/src/main/ruby/lib/finagle-thrift.rb
+++ b/finagle-thrift/src/main/ruby/lib/finagle-thrift.rb
@@ -7,8 +7,9 @@ require 'finagle-thrift/thrift/tracing_types'
 
 require 'finagle-thrift/client'
 require 'finagle-thrift/thrift_client'
-require 'finagle-thrift/trace'
 require 'finagle-thrift/tracer'
+require 'finagle-thrift/trace'
+
 
 module FinagleThrift
   extend self

--- a/finagle-thrift/src/main/ruby/lib/finagle-thrift/version.rb
+++ b/finagle-thrift/src/main/ruby/lib/finagle-thrift/version.rb
@@ -1,4 +1,4 @@
 module FinagleThrift
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end
 

--- a/finagle-thrift/src/main/ruby/test/test_helper.rb
+++ b/finagle-thrift/src/main/ruby/test/test_helper.rb
@@ -1,0 +1,19 @@
+base_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+lib_dir  = File.join(base_dir, "lib")
+test_dir = File.join(base_dir, "test")
+
+$LOAD_PATH.unshift(lib_dir)
+
+require 'test/unit'
+require 'rubygems'
+require 'thrift'
+require 'finagle-thrift'
+
+# needs jruby for true test
+def create_race_condition
+  10.times.map do
+    Thread.new do
+      100.times { yield }
+    end
+  end.each(&:join)
+end


### PR DESCRIPTION
When this library is used with jruby there are some thread safety issues.  This PR adds a threadsafe array and synchronizes some of the methods.
