### PR TITLE
Make trace stack thread local

### DIFF
--- a/finagle-thrift/src/main/ruby/.gitignore
+++ b/finagle-thrift/src/main/ruby/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/finagle-thrift/src/main/ruby/Gemfile
+++ b/finagle-thrift/src/main/ruby/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in finagle-thrift.gemspec
+gemspec
+

--- a/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb
+++ b/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb
@@ -33,7 +33,7 @@ module Trace
         saved_stack = stack.dup
         yield
       ensure
-        @stack = saved_stack
+        stack = saved_stack
       end
     end
   end
@@ -55,6 +55,10 @@ module Trace
 
   def tracer=(tracer)
     @tracer = tracer
+  end
+
+  def stack=(stack)
+    Thread.current[:trace_stack] = stack
   end
 
   class TraceId
@@ -85,11 +89,11 @@ module Trace
       "TraceId(trace_id = #{@trace_id.to_s}, parent_id = #{@parent_id.to_s}, span_id = #{@span_id.to_s}, sampled = #{@sampled.to_s}, flags = #{@flags.to_s})"
     end
   end
-  
+
   # there are a total of 64 flags that can be passed down with the various tracing headers
   # at the time of writing only one is used (debug).
   #
-  # Note that using the 64th bit in Ruby requires some sign conversion since Thrift i64s are signed 
+  # Note that using the 64th bit in Ruby requires some sign conversion since Thrift i64s are signed
   # but Ruby won't do the right thing if you try to set 1 << 64
   class Flags
     # no flags set
@@ -147,7 +151,7 @@ module Trace
   private
 
   def stack
-    @stack ||= []
+    Thread.current[:trace_stack] ||= []
   end
 
   def tracer

--- a/finagle-thrift/src/main/ruby/lib/finagle-thrift/version.rb
+++ b/finagle-thrift/src/main/ruby/lib/finagle-thrift/version.rb
@@ -1,4 +1,4 @@
 module FinagleThrift
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end
 

--- a/finagle-thrift/src/main/ruby/test/test_helper.rb
+++ b/finagle-thrift/src/main/ruby/test/test_helper.rb
@@ -1,0 +1,10 @@
+base_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+lib_dir  = File.join(base_dir, "lib")
+test_dir = File.join(base_dir, "test")
+
+$LOAD_PATH.unshift(lib_dir)
+
+require 'test/unit'
+require 'rubygems'
+require 'thrift'
+require 'finagle-thrift'

--- a/finagle-thrift/src/main/ruby/test/trace_test.rb
+++ b/finagle-thrift/src/main/ruby/test/trace_test.rb
@@ -1,7 +1,4 @@
-require 'rubygems'
-require 'thrift'
-require 'finagle-thrift'
-require 'test/unit'
+require_relative 'test_helper'
 
 class TraceIdTest < Test::Unit::TestCase
   def test_debug_flag
@@ -21,5 +18,19 @@ class TraceIdTest < Test::Unit::TestCase
     id = Trace::SpanId.new(Trace.generate_id)
     id2 = Trace::SpanId.from_value(id.to_s)
     assert_equal id.to_i, id2.to_i
+  end
+end
+
+class TraceTest < Test::Unit::TestCase
+  def test_stack_object_id
+    obj_id1 = Thread.new { Trace.id; Trace.send(:stack).object_id }.value
+    obj_id2 = Thread.new { Trace.id; Trace.send(:stack).object_id }.value
+    assert_not_equal obj_id1, obj_id2
+  end
+
+  def test_stack=
+    Trace.stack = [1]
+    stack = Trace.send(:stack)
+    assert_equal [1], stack
   end
 end


### PR DESCRIPTION
Trace's global stack variable is not thread safe.  Changing to be thread local for thread safety.

@oscil8
